### PR TITLE
Add lesson completion tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package-lock.json
+.next
+.DS_Store

--- a/backend/data.js
+++ b/backend/data.js
@@ -1,0 +1,35 @@
+const bcrypt = require('bcryptjs')
+
+// начальные курсы и уроки
+const courses = [
+  {
+    id: 'math-1',
+    title: 'Математика. Базовый курс',
+    description: 'Простой курс по математике',
+    lessons: [
+      { id: 'math-1-1', title: 'Сложение', videoUrl: '', task: 'Решите 2+2' },
+      { id: 'math-1-2', title: 'Вычитание', videoUrl: '', task: 'Решите 5-3' }
+    ]
+  },
+  {
+    id: 'rus-1',
+    title: 'Русский язык',
+    description: 'Основы русского языка',
+    lessons: [
+      { id: 'rus-1-1', title: 'Орфография', videoUrl: '', task: 'Напишите слово' }
+    ]
+  }
+]
+
+// пользователи и прогресс
+const users = [] // {id, name, email, passwordHash, role, progress: []}
+
+function createUser({ name, email, password, role = 'student' }) {
+  const id = Date.now().toString()
+  const passwordHash = bcrypt.hashSync(password, 10)
+  const user = { id, name, email, passwordHash, role, progress: [] }
+  users.push(user)
+  return user
+}
+
+module.exports = { courses, users, createUser }

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,78 @@
-const express = require('express');
-const app = express();
-app.use(express.json());
-app.get('/', (req, res) => res.send('Backend работает'));
-app.listen(5000, () => console.log('Сервер запущен на порту 5000'));
+const express = require('express')
+const jwt = require('jsonwebtoken')
+const bcrypt = require('bcryptjs')
+const cors = require('cors')
+const { courses, users, createUser } = require('./data')
+
+const app = express()
+app.use(cors())
+app.use(express.json())
+
+const JWT_SECRET = 'secret'
+
+// создать пользователя по умолчанию для демонстрации
+if (users.length === 0) {
+  createUser({ name: 'Иван', email: 'ivan@example.com', password: '1234' })
+}
+
+function auth(req, res, next) {
+  const authHeader = req.headers.authorization
+  if (!authHeader) return res.status(401).send('No token')
+  const token = authHeader.split(' ')[1]
+  try {
+    req.user = jwt.verify(token, JWT_SECRET)
+    next()
+  } catch {
+    res.status(401).send('Invalid token')
+  }
+}
+
+app.get('/', (req, res) => res.send('Backend работает'))
+
+app.post('/api/register', (req, res) => {
+  const { name, email, password } = req.body
+  if (users.find(u => u.email === email)) return res.status(400).send('Exists')
+  const user = createUser({ name, email, password })
+  const token = jwt.sign({ id: user.id, role: user.role }, JWT_SECRET)
+  res.json({ token })
+})
+
+app.post('/api/login', (req, res) => {
+  const { email, password } = req.body
+  const user = users.find(u => u.email === email)
+  if (!user) return res.status(400).send('User not found')
+  if (!bcrypt.compareSync(password, user.passwordHash)) return res.status(400).send('Wrong password')
+  const token = jwt.sign({ id: user.id, role: user.role }, JWT_SECRET)
+  res.json({ token })
+})
+
+app.get('/api/courses', (req, res) => {
+  res.json(courses)
+})
+
+app.get('/api/courses/:id', (req, res) => {
+  const course = courses.find(c => c.id === req.params.id)
+  if (!course) return res.status(404).send('Not found')
+  res.json(course)
+})
+
+app.get('/api/me', auth, (req, res) => {
+  const user = users.find(u => u.id === req.user.id)
+  if (!user) return res.status(404).send('Not found')
+  res.json({ user: { id: user.id, name: user.name, role: user.role }, progress: user.progress })
+})
+
+app.post('/api/lessons/:id/complete', auth, (req, res) => {
+  const { id } = req.params
+  const user = users.find(u => u.id === req.user.id)
+  if (!user) return res.status(404).send('Not found')
+  const course = courses.find(c => c.lessons.some(l => l.id === id))
+  if (!course) return res.status(404).send('Lesson not found')
+  const lesson = course.lessons.find(l => l.id === id)
+  if (!user.progress.find(p => p.lessonId === id)) {
+    user.progress.push({ lessonId: id, lessonTitle: lesson.title })
+  }
+  res.json({ success: true })
+})
+
+app.listen(5000, () => console.log('Сервер запущен на порту 5000'))

--- a/frontend/components/CourseCard.jsx
+++ b/frontend/components/CourseCard.jsx
@@ -1,1 +1,12 @@
-// Карточка курса
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+
+export default function CourseCard({ course }) {
+  return (
+    <motion.div whileHover={{ scale: 1.02 }} className="bg-edu-card rounded-lg p-4 shadow hover:shadow-md">
+      <h2 className="font-semibold text-lg mb-2">{course.title}</h2>
+      <p className="mb-2">{course.description}</p>
+      <Link href={`/course/${course.id}`} className="inline-block mt-2 bg-edu-accent text-gray-900 px-3 py-1 rounded">Перейти</Link>
+    </motion.div>
+  )
+}

--- a/frontend/components/Header.jsx
+++ b/frontend/components/Header.jsx
@@ -1,1 +1,8 @@
-// Компонент шапки
+export default function Header({ user }) {
+  return (
+    <header className="bg-edu-accent text-gray-900 p-4 flex justify-between rounded-b-lg shadow">
+      <h1 className="font-bold text-lg">EduVerse</h1>
+      {user && <span>Привет, {user.name}</span>}
+    </header>
+  )
+}

--- a/frontend/components/Layout.jsx
+++ b/frontend/components/Layout.jsx
@@ -1,0 +1,10 @@
+import Header from './Header'
+
+export default function Layout({ children, user }) {
+  return (
+    <div className="min-h-screen font-mont bg-edu-bg text-gray-800">
+      <Header user={user} />
+      <main className="p-4">{children}</main>
+    </div>
+  )
+}

--- a/frontend/pages/_app.jsx
+++ b/frontend/pages/_app.jsx
@@ -1,0 +1,15 @@
+import '../styles/globals.css'
+import Head from 'next/head'
+
+export default function App({ Component, pageProps }) {
+  return (
+    <>
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet" />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  )
+}

--- a/frontend/pages/course/[id].jsx
+++ b/frontend/pages/course/[id].jsx
@@ -1,1 +1,35 @@
-// Страница урока курса
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import Header from '../../components/Header'
+
+export default function CoursePage() {
+  const { query } = useRouter()
+  const [course, setCourse] = useState(null)
+
+  useEffect(() => {
+    if (!query.id) return
+    fetch(`http://localhost:5000/api/courses/${query.id}`)
+      .then(res => res.json())
+      .then(setCourse)
+  }, [query.id])
+
+  if (!course) return <div>Загрузка...</div>
+
+  return (
+    <div>
+      <Header />
+      <div className="p-4">
+        <h1 className="text-2xl mb-4">{course.title}</h1>
+        <ul className="space-y-2">
+          {course.lessons.map(lesson => (
+            <li key={lesson.id} className="border p-2 rounded">
+              <div className="font-semibold">{lesson.title}</div>
+              <video src={lesson.videoUrl} controls className="w-full my-2" />
+              <p>{lesson.task}</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/frontend/pages/dashboard.jsx
+++ b/frontend/pages/dashboard.jsx
@@ -1,1 +1,69 @@
-// Кабинет ученика
+import Layout from '../components/Layout'
+import { motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
+
+export default function Dashboard() {
+  const [user, setUser] = useState(null)
+  const [courses, setCourses] = useState([])
+
+  useEffect(() => {
+    fetch('http://localhost:5000/api/courses')
+      .then((res) => res.json())
+      .then(setCourses)
+
+    const token = localStorage.getItem('token')
+    if (token) {
+      fetch('http://localhost:5000/api/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => res.json())
+        .then((data) => setUser(data))
+    }
+  }, [])
+
+  if (!user) return <Layout>Загрузка...</Layout>
+
+  const progressMap = user.progress.reduce((acc, item) => {
+    const course = courses.find((c) => c.lessons.some((l) => l.id === item.lessonId))
+    if (course) {
+      acc[course.id] = acc[course.id] || { course, completed: 0 }
+      acc[course.id].completed += 1
+    }
+    return acc
+  }, {})
+
+  return (
+    <Layout user={{ name: user.user.name }}>
+      <h1 className="text-2xl font-semibold mb-6">Привет, {user.user.name}!</h1>
+      <div className="space-y-6">
+        {courses.map((course) => {
+          const completed = progressMap[course.id]?.completed || 0
+          const total = course.lessons.length
+          const percent = Math.round((completed / total) * 100)
+          return (
+            <div key={course.id} className="bg-edu-card p-4 rounded-lg shadow">
+              <h2 className="font-medium text-lg mb-2">{course.title}</h2>
+              <div className="h-2 bg-gray-200 rounded overflow-hidden">
+                <motion.div
+                  className="h-2 bg-edu-accent"
+                  initial={{ width: 0 }}
+                  animate={{ width: `${percent}%` }}
+                  transition={{ duration: 0.5 }}
+                />
+              </div>
+              <p className="text-sm mt-1">{percent}% пройдено</p>
+              <ul className="mt-2 pl-4 list-disc space-y-1">
+                {course.lessons.slice(0, completed).map((lesson, i) => (
+                  <li key={lesson.id} className="flex items-center text-sm">
+                    <span className="text-edu-accent mr-2">✓</span>
+                    {lesson.title} пройдено
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )
+        })}
+      </div>
+    </Layout>
+  )
+}

--- a/frontend/pages/index.jsx
+++ b/frontend/pages/index.jsx
@@ -1,1 +1,23 @@
-// Главная страница
+import { useEffect, useState } from 'react'
+import CourseCard from '../components/CourseCard'
+import Layout from '../components/Layout'
+
+export default function Home() {
+  const [courses, setCourses] = useState([])
+
+  useEffect(() => {
+    fetch('http://localhost:5000/api/courses')
+      .then(res => res.json())
+      .then(setCourses)
+  }, [])
+
+  return (
+    <Layout>
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        {courses.map(c => (
+          <CourseCard key={c.id} course={c} />
+        ))}
+      </div>
+    </Layout>
+  )
+}

--- a/frontend/pages/lesson/[id].jsx
+++ b/frontend/pages/lesson/[id].jsx
@@ -1,0 +1,96 @@
+import { useRouter } from 'next/router'
+import { useState, useEffect } from 'react'
+import Layout from '../../components/Layout'
+import { motion } from 'framer-motion'
+
+const lessons = [
+  {
+    id: 'math-1',
+    title: 'Математика. Урок 1',
+    videoUrl: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
+    text: 'В этом уроке ты узнаешь основы деления...',
+    question: 'Сколько будет 12 / 4?',
+    correctAnswer: '3'
+  }
+]
+
+export default function LessonPage() {
+  const { query } = useRouter()
+  const [lesson, setLesson] = useState(null)
+  const [answer, setAnswer] = useState('')
+  const [completed, setCompleted] = useState(false)
+
+  useEffect(() => {
+    if (!query.id) return
+    const l = lessons.find(l => l.id === query.id)
+    setLesson(l)
+
+    const token = localStorage.getItem('token')
+    if (token) {
+      fetch('http://localhost:5000/api/me', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          if (data.progress.find((p) => p.lessonId === query.id)) {
+            setCompleted(true)
+          }
+        })
+    }
+  }, [query.id])
+
+  const handleComplete = async () => {
+    const token = localStorage.getItem('token')
+    if (token) {
+      await fetch(`http://localhost:5000/api/lessons/${lesson.id}/complete`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` }
+      })
+    }
+    setCompleted(true)
+  }
+
+  if (!lesson) return <Layout><div>Урок не найден</div></Layout>
+
+  return (
+    <Layout>
+      <div className="max-w-2xl mx-auto space-y-4">
+        <div className="h-2 bg-gray-200 rounded overflow-hidden">
+          <motion.div
+            className="h-2 bg-edu-accent"
+            initial={{ width: 0 }}
+            animate={{ width: completed ? '100%' : '0%' }}
+            transition={{ duration: 0.5 }}
+          />
+        </div>
+        <div className="bg-edu-card rounded-lg p-4 shadow">
+          <h1 className="text-xl font-semibold mb-4">{lesson.title}</h1>
+          <div className="aspect-video mb-4">
+            <iframe
+              src={lesson.videoUrl}
+              title={lesson.title}
+              className="w-full h-full rounded"
+              allowFullScreen
+            ></iframe>
+          </div>
+          <p className="mb-4">{lesson.text}</p>
+          <div className="mb-4">
+            <label className="block mb-2 font-medium">{lesson.question}</label>
+            <input
+              type="text"
+              className="p-2 w-full rounded border"
+              value={answer}
+              onChange={e => setAnswer(e.target.value)}
+            />
+          </div>
+          <button
+            onClick={handleComplete}
+            className="bg-edu-accent text-gray-900 px-4 py-2 rounded"
+          >
+            Завершить урок
+          </button>
+        </div>
+      </div>
+    </Layout>
+  )
+}

--- a/frontend/pages/login.jsx
+++ b/frontend/pages/login.jsx
@@ -1,1 +1,35 @@
-// Страница входа
+import { useState } from 'react'
+
+export default function Login() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async e => {
+    e.preventDefault()
+    const res = await fetch('http://localhost:5000/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    })
+    if (res.ok) {
+      const { token } = await res.json()
+      localStorage.setItem('token', token)
+      window.location.href = '/dashboard'
+    } else {
+      setError('Неверные данные')
+    }
+  }
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-xl mb-4">Вход</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input className="border p-2 w-full" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+        <input className="border p-2 w-full" type="password" placeholder="Пароль" value={password} onChange={e => setPassword(e.target.value)} />
+        {error && <p className="text-red-600">{error}</p>}
+        <button className="bg-blue-600 text-white px-4 py-2" type="submit">Войти</button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply font-mont bg-edu-bg text-gray-800;
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,23 @@
   "description": "Образовательная платформа",
   "main": "index.js",
   "scripts": {
-    "start": "node backend/server.js"
+    "start": "node backend/server.js",
+    "dev": "next dev -p 3000"
+  },
+  "dependencies": {
+    "bcryptjs": "^3.0.2",
+    "cors": "^2.8.5",
+    "express": "^5.1.0",
+    "framer-motion": "^11.0.0",
+    "jsonwebtoken": "^9.0.2",
+    "next": "^15.3.5",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.11",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.11"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  content: [
+    './frontend/pages/**/*.{js,jsx}',
+    './frontend/components/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        'edu-bg': '#e8f5ff',
+        'edu-card': '#d1f5d3',
+        'edu-accent': '#ffb300'
+      },
+      fontFamily: {
+        mont: ['Montserrat', 'sans-serif']
+      }
+    },
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- store progress directly on users
- ensure backend updates progress when finishing lessons
- preload a sample user
- fetch progress in dashboard and calculate course stats
- reflect lesson completion in lesson page

## Testing
- `curl -s http://localhost:5000/`
- `curl -s -X POST http://localhost:5000/api/login -H 'Content-Type: application/json' -d '{"email":"ivan@example.com","password":"1234"}'`
- `curl -s http://localhost:5000/api/me -H "Authorization: Bearer $TOKEN"`
- `npx next build frontend`


------
https://chatgpt.com/codex/tasks/task_e_686a7287dbb0832689f7e8f85241f663